### PR TITLE
feat: add automatic disconnect from ECP bus on OTA

### DIFF
--- a/src/VistaAlarm.yaml
+++ b/src/VistaAlarm.yaml
@@ -88,6 +88,9 @@ api:
 ota:
    password: !secret ota_password
    safe_mode: True
+   on_begin:
+    - lambda: |-
+        disconnectVista();
    
 #status_led:
  # pin:


### PR DESCRIPTION
This avoids the issues with interrupts during OTAs by using [ota.on_begin](https://esphome.io/components/ota.html#on-begin) to disable ECP. The ESP is rebooted at the conclusion of the OTA regardless, so no need to reset it ourselves.